### PR TITLE
Add _redirects to build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,7 @@ const pluginRss = require("@11ty/eleventy-plugin-rss");
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("assets");
   eleventyConfig.addPassthroughCopy("slides");
+  eleventyConfig.addPassthroughCopy("_redirects");
 
   Object.entries(filters).forEach(([name, callback]) => {
     eleventyConfig.addFilter(name, callback);


### PR DESCRIPTION
On development (with `netlify dev`), the engine picks up redirects from root but in production, it needs to be built into the site.

This adds that to the previous change at #9 .