### PR TITLE
Center footer heading

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -215,6 +215,7 @@ footer {
 
 footer h2 {
   text-transform: uppercase;
+  text-align: center;
 }
 
 footer .container {


### PR DESCRIPTION
I hadn't noticed that a CSS change for blog headers had also moved the footer header to the left.

Before
![Screenshot 2024-01-08 at 14 46 00](https://github.com/archipylago/archipylago.dev/assets/1909996/2ee40d21-7c2b-4d8e-a45d-f0340298a9b6)

After
![Screenshot 2024-01-08 at 14 45 46](https://github.com/archipylago/archipylago.dev/assets/1909996/7dc3f26a-446e-4b48-ae7a-4a3d8cc8b2c9)
