### PR TITLE
blog: Add h-entry microformat stuff for the posts

### DIFF
--- a/_includes/layouts/blog.njk
+++ b/_includes/layouts/blog.njk
@@ -2,16 +2,19 @@
 layout: layouts/base.njk
 ---
 
-<div id="blog-post">
-    <header>
-        <h1>{{ title }}</h1>
-        <div class="info">
-            <span class="date">Published {{ date | toLocalDateYear }}</span>
-            <span class="author">by {{ author }}</span>
-        </div>
-        </header>
+<div id="blog-post" class="h-entry">
+  <header>
+    <h1 class="p-name">{{ title }}</h1>
+    <div class="info">
+      <span class="date"
+        >Published
+        <time class="dt-published">{{ date | toLocalDateYear }}</time></span
+      >
+      <span class="author">by <span class="p-author">{{ author }}</span></span>
+    </div>
+  </header>
 
-{{ content | safe }}
+  <div class="e-content">{{ content | safe }}</div>
 </div>
 
 <script src="/assets/prism.js"></script>


### PR DESCRIPTION
For IndieWeb integration (like nice output for Webmentions), I've adjusted blog to include `h-entry`, `p-name`, `p-author` and `e-content` according to [microformats documentation](http://microformats.org/wiki/h-entry)