### PR TITLE
Ignore VS Code settings, add redirects for Mastodon and Meetabit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 _site/
 .DS_Store
+.vscode/

--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,3 @@
 /discord https://discord.gg/pAAARVc5F7
 /@archipylago https://mementomori.social/@archipylago
+/meetabit https://meetabit.com/communities/archipylago

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,2 @@
 /discord https://discord.gg/pAAARVc5F7
+/@archipylago https://mementomori.social/@archipylago


### PR DESCRIPTION
## New redirects

### Mastodon
Provides an easier to remember URL for reaching our Mastodon account and offering us a way to keep one URL even if we change instances

https://archipylago.dev/@archipylago -> https://mementomori.social/@archipylago

### Meetabit

Provides an easier to remember and share URL for finding our Meetabit page

https://archipylago.dev/meetabit -> https://meetabit.com/communities/archipylago

## git to ignore VS Code settings

`.vscode/` is a config folder for developer specific settings so let's ignore that so everyone can set their own settings.