### PR TITLE
Add info pages for speakers and sponsors

### DIFF
--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -1,18 +1,23 @@
 <h1>archipylago</h1>
 <nav>
-    <ul>
-        <li>
-            <a href="/">Home</a>
-        </li>
-        <li>
-            <a href="/blog">Blog</a>
-        </li>
-        <li>
-            <a href="/feed/feed.xml">RSS</a>
-        </li>
-    </ul>
+  <ul>
+    <li>
+      <a href="/">Home</a>
+    </li>
+    <li>
+      <a href="/blog">Blog</a>
+    </li>
+    <li>
+      <a href="/for-speakers">For speakers</a>
+    </li>
+    <li>
+      <a href="/for-companies">For companies</a>
+    </li>
+    <li>
+      <a href="/feed/feed.xml">RSS</a>
+    </li>
+  </ul>
 </nav>
 <p class="tagline">Your friendly Python community in Turku</p>
 
 <p class="tagline"><em>archipylago = archipelago + python</em></p>
-

--- a/_includes/layouts/page.njk
+++ b/_includes/layouts/page.njk
@@ -1,0 +1,5 @@
+---
+layout: layouts/base.njk
+---
+
+<div class="page">{{ content | safe }}</div>

--- a/assets/main.css
+++ b/assets/main.css
@@ -499,23 +499,28 @@ a {
   color: #3776ab;
 }
 
-#blog-post {
+#blog-post,
+.page {
   max-width: 100ch;
   margin: auto;
 }
 
 #blog-post p:not(:last-child),
-#blog-post ul {
+#blog-post ul,
+.page p:not(:last-child),
+.page ul {
   margin-bottom: 1em;
 }
 
-#blog-post .info {
+#blog-post .info,
+.page .info {
   text-align: center;
   font-style: italic;
   margin-bottom: 1em;
 }
 
-#blog-post h2 {
+#blog-post h2,
+.page h2 {
   font-size: 1.5em;
   margin: 0.75em 0;
 }
@@ -533,6 +538,7 @@ nav ul {
   padding: 0;
 }
 
-#blog-index h1 {
+#blog-index h1,
+.page h1 {
   margin-bottom: 1em;
 }

--- a/for-companies.md
+++ b/for-companies.md
@@ -1,0 +1,36 @@
+---
+layout: layouts/page.njk
+title: For companies
+---
+
+# Information for companies
+
+archipylago is a non-profit community for Python developers in Turku area.
+
+With the help of our partner companies, we host meetups in their offices to bring the developer community together to learn, get inspired, meet other developers and learn about the companies.
+
+Our meetups happen on Thursday evenings, 18.00-20.30 and consist of a short company introduction, 2 talks about Python related topics, food and drinks and time to sosialize and hang out.
+
+## Responsibilities
+
+We as the **organizers** take care of booking the speakers, handling marketing and registrations and bringing the community to your office.
+
+You as the sponsoring **company** in return offer us space for the event with AV setup (minimum of a display that we can connect laptops to) as well as food and drinks for the participants.
+
+How many people we bring in always depends on the available space and company: we usually aim to have space for 20-50 people. That's usually been the amount of people offices in Turku are able to accomodate.
+
+## Schedule
+
+A rough schedule for our events looks like this:
+
+18.00 Doors open  
+18.10 Hello from hosting company
+18.20 1st talk
+18.50 Break  
+19.10 2nd talk
+19.40 Socializing  
+20.30 Post-meetup discussions at a local pub
+
+but the exact timings inside the event can shift around.
+
+And we're always open to discuss new ideas and formats if you have something specific in mind.

--- a/for-speakers.md
+++ b/for-speakers.md
@@ -1,0 +1,33 @@
+---
+layout: layouts/page.njk
+title: For speakers
+---
+
+# Information for speakers
+
+We welcome speakers of all kind to give talks in archipylago meetups. The main idea for the meetup is to have space for developers to share with each other what they know, what they've learned and what experiences they have. You can be an experienced conference/meetup speaker or a first-timer; a senior developer or a hobbyist. We aim to have a space that is welcoming and safe to experiment with public speaking.
+
+## Practicalities
+
+By default, we expect talks to be:
+
+- up to 30 minutes in length (if you have a longer talk in mind, let's discuss!)
+- in English
+- about topics relevant to Python developers
+- not direct product or company marketing
+- in line with our [Code of Conduct](/#code-of-conduct)
+
+A typical talk has some slides and/or live coding sections but we're open to all sorts of creative talks so don't let that typical setup stop you.
+
+## What can you talk about?
+
+If you'd like to give a talk but don't yet know quite what about, here are some ideas:
+
+- **Python tools and libraries** are common things to talk about. Have you found an interesting tool or library that you use in your daily projects and want to share that with others. There's so many out there that it's likely not everybody knows about the same tools you use.
+- **Project learnings** give inspiration and ideas to others. If you've worked on a work project that you can talk about or a hobby project recently, come share what you've learned.
+- **Tools for developers** that are not exactly Python-specific (like editors, command line tools, deployment, etc).
+- **What's new in Python and ecosystem**: tools and languages evolve over time but it can be hard to keep up in the daily grind. Why not share some of the new exciting things with the community?
+
+Juhis has shared more ideas with examples in his blog: [Talk ideas for new and experienced speakers](https://hamatti.org/posts/talk-ideas-for-new-and-experienced-speakers/) that you can check out for inspiration.
+
+If you want help with ideation, crafting the talk and practice before the meetup, we're happy to help you out!


### PR DESCRIPTION
I added basic information pages we can share with potential speakers and sponsors as we talk with them so we don't have to rely on remembering everything.